### PR TITLE
Communicated purpose of brain card entry as visual-only log of change over time

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -2739,7 +2739,7 @@ I hope you will have lots of fun!
         // Add metadata and initialize the brain object in the log
         agent.card.entry = `${agent.card.entry.trimStart()}\n${path("metadata")} = ${(
             JSON.stringify(agent.metadata, null, 2)
-        )};\n${path()} = {};`;
+        )};\n${path()} = {};\n// Entry: Displays recent brain operations to the player\n// Triggers: Configurable settings for this NPC alone\n// Notes: Allows the player to view/edit actual brain contents`;
     }
     // Update the hashcode to mark this history state as processed
     IS.hash = hash;


### PR DESCRIPTION
Added explanatory comments to brain card entry initialization header. Hopefully players will read this and understand the card entry is merely a log of change over time; the actual brain is stored under the card notes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves clarity of brain card initialization without changing behavior.
> 
> - In `src/library.js`, when initializing a fresh `agent.card.entry`, appends explanatory comments detailing `Entry`, `Triggers`, and `Notes` sections.
> - No logic or data flow changes; purely comment/documentation update in the generated entry text.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7863c850025ce18c18433eff2c5a60dc99467d61. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->